### PR TITLE
Changed value of rows for maven central requests

### DIFF
--- a/rest-lib-utils/src/main/java/org/eclipse/steady/cia/rest/ClassController.java
+++ b/rest-lib-utils/src/main/java/org/eclipse/steady/cia/rest/ClassController.java
@@ -116,13 +116,13 @@ public class ClassController {
    * <p>getClassArtifacts.</p>
    *
    * @param classname a {@link java.lang.String} object.
-   * @param rows a {@link java.lang.String} object.
+   * @param rows a {@link java.lang.String} object (max allowed value: 989, default: 989).
    * @return a {@link org.springframework.http.ResponseEntity} object.
    */
   @RequestMapping(value = "/libraryIds/{classname:.+}", method = RequestMethod.GET)
   public ResponseEntity<Set<Artifact>> getClassArtifacts(
       @PathVariable String classname,
-      @RequestParam(value = "rows", required = false, defaultValue = "1000") String rows) {
+      @RequestParam(value = "rows", required = false, defaultValue = "989") String rows) {
     try {
       //			final String url = "http://search.maven.org/solrsearch/select?q={q}&rows={rows}&wt={wt}";
       //			final StringBuilder query = new StringBuilder();

--- a/rest-lib-utils/src/main/java/org/eclipse/steady/cia/util/MavenCentralWrapper.java
+++ b/rest-lib-utils/src/main/java/org/eclipse/steady/cia/util/MavenCentralWrapper.java
@@ -179,7 +179,7 @@ public class MavenCentralWrapper implements RepositoryWrapper {
       // same for classifier
       params.put("q", constructQ(mvnGroup, artifact, version, null, null).toString());
       params.put("core", "gav");
-      params.put("rows", "1000");
+      params.put("rows", "989");
       params.put("wt", "json");
 
       // Make the query

--- a/rest-lib-utils/src/test/java/org/eclipse/steady/cia/rest/IT03_ClassControllerTest.java
+++ b/rest-lib-utils/src/test/java/org/eclipse/steady/cia/rest/IT03_ClassControllerTest.java
@@ -35,7 +35,7 @@ public class IT03_ClassControllerTest {
     try {
       Set<Artifact> response =
           r.getArtifactForClass(
-              "org.apache.commons.fileupload.MultipartStream", "1000", null, "jar");
+              "org.apache.commons.fileupload.MultipartStream", "989", null, "jar");
 
       System.out.println(response.size());
       assertTrue(response.size() >= 172);


### PR DESCRIPTION
With the previous value of rows (1000), requests return 400, e.g.,

https://search.maven.org/solrsearch/select?q=g:%22commons-fileupload%22%20AND%20a:%22commons-fileupload%22&core=gav&rows=1000

rows=989 seems to be the max allowed value. However I didn't find any information in the api guide.